### PR TITLE
Fix subproduct file upload path

### DIFF
--- a/apps/products/api/views/subproduct_files_view.py
+++ b/apps/products/api/views/subproduct_files_view.py
@@ -53,7 +53,11 @@ def subproduct_file_upload_view(request, product_id: str, subproduct_id: str):
     results, errors = [], []
     for file in files:
         try:
-            result = upload_subproduct_file(file=file, subproduct_id=int(subproduct_id))
+            result = upload_subproduct_file(
+                file=file,
+                product_id=int(product_id),
+                subproduct_id=int(subproduct_id),
+            )
             SubproductFileRepository.create(
                 subproduct_id=int(subproduct_id),
                 key=result["key"],


### PR DESCRIPTION
## Summary
- ensure subproduct file uploads include product id when saving

## Testing
- `pytest -q` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_685b69f6146c832b8c9c11a5639f5f61