### PR TITLE
Corrige suma de subproductos en validación de stock

### DIFF
--- a/apps/stocks/services/stocks_services.py
+++ b/apps/stocks/services/stocks_services.py
@@ -267,12 +267,14 @@ def validate_and_correct_stock():
         
 
         for subproduct in product.subproducts.all():
-            total_subproduct_quantity += subproduct.quantity
-            total_subproduct_quantity += (
-                SubproductStock.objects
-                    .filter(subproduct=subproduct, status=True)
-                    .aggregate(total=Sum('quantity'))['total'] or Decimal('0.00')
+            total_subproduct_quantity += Decimal(
+                subproduct.initial_stock_quantity or 0
             )
+            active_total = SubproductStock.objects.filter(
+                subproduct=subproduct,
+                status=True
+            ).aggregate(total=Sum('quantity'))['total']
+            total_subproduct_quantity += Decimal(active_total or 0)
         try:
             stock_record = product.stock_record
         except ProductStock.DoesNotExist:


### PR DESCRIPTION
## Summary
- corregir `validate_and_correct_stock` para usar `initial_stock_quantity`
- sumar cantidades de `SubproductStock` activos usando `Decimal`

## Testing
- `pytest -q` *(falla: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_685b69f724c8832b991b619d479ef50e