### PR TITLE
Implement cutting order enhancements

### DIFF
--- a/apps/cuts/docs/cutting_order_doc.py
+++ b/apps/cuts/docs/cutting_order_doc.py
@@ -60,7 +60,11 @@ list_assigned_cutting_orders_doc = {
 create_cutting_order_doc = {
     'operation_id': 'create_cutting_order',
     'summary': 'Crea una nueva orden de corte.',
-    'description': 'Crea una nueva orden de corte. Solo usuarios staff pueden crear órdenes de corte.',
+    'description': (
+        'Crea una nueva orden de corte asociada a un producto y con múltiples subproductos. '
+        'Solo usuarios staff pueden crear órdenes. El campo `operator_can_edit_items` '
+        'indica si el operario asignado podrá modificar los items.'
+    ),
     'tags': ['Cutting Orders'],
     'security': [{'jwtAuth': []}],
     'requestBody': {
@@ -121,7 +125,8 @@ update_cutting_order_by_id_doc = {
     'description': (
         'Actualiza una orden de corte específica.\n\n'
         '• Usuarios staff pueden modificar cualquier campo.\n'
-        '• Usuarios asignados pueden actualizar solo el campo `workflow_status`.'
+        '• Usuarios asignados pueden actualizar solo el campo `workflow_status`'
+        ' o también los `items` cuando `operator_can_edit_items` es verdadero.'
     ),
     'tags': ['Cutting Orders'],
     'security': [{'jwtAuth': []}],

--- a/apps/cuts/models/cutting_order_model.py
+++ b/apps/cuts/models/cutting_order_model.py
@@ -4,6 +4,7 @@ from django.utils import timezone
 from django.conf import settings
 
 from apps.products.models.subproduct_model import Subproduct
+from apps.products.models.product_model import Product
 from apps.products.models.base_model import BaseModel
 
 
@@ -27,6 +28,12 @@ class CuttingOrder(BaseModel):
         unique=True,
         default=0
     )
+    product = models.ForeignKey(
+        Product,
+        on_delete=models.PROTECT,
+        related_name='cutting_orders',
+        verbose_name='Producto'
+    )
     customer = models.CharField(
         max_length=255,
         help_text='Cliente para quien es la orden de corte',
@@ -42,6 +49,10 @@ class CuttingOrder(BaseModel):
     completed_at = models.DateTimeField(
         null=True, blank=True,
         verbose_name='Fecha de Completado'
+    )
+    operator_can_edit_items = models.BooleanField(
+        default=False,
+        verbose_name='Operario puede editar items'
     )
 
     class Meta:

--- a/apps/cuts/tests_new.py
+++ b/apps/cuts/tests_new.py
@@ -1,0 +1,59 @@
+from rest_framework.test import APITestCase
+from django.urls import reverse
+from rest_framework import status
+from django.contrib.auth import get_user_model
+from apps.products.models import Category, Product, Subproduct
+from apps.stocks.models import SubproductStock
+from apps.cuts.models.cutting_order_model import CuttingOrder
+
+User = get_user_model()
+
+class CuttingOrderNewTests(APITestCase):
+    def setUp(self):
+        self.admin = User.objects.create_superuser(
+            username='admin', email='a@example.com', name='Admin', last_name='Ln', password='pass'
+        )
+        self.operator = User.objects.create_user(
+            username='op', email='o@example.com', name='Op', last_name='Ln', password='pass'
+        )
+        self.category = Category.objects.create(name='Cat')
+        self.product = Product.objects.create(name='Prod', category=self.category, has_subproducts=True)
+        self.sub1 = Subproduct.objects.create(parent=self.product)
+        self.sub2 = Subproduct.objects.create(parent=self.product)
+        SubproductStock.objects.create(subproduct=self.sub1, quantity=50, created_by=self.admin)
+        SubproductStock.objects.create(subproduct=self.sub2, quantity=50, created_by=self.admin)
+        self.client.force_authenticate(user=self.admin)
+
+    def test_create_order_multiple_items(self):
+        url = reverse('cutting_order_create')
+        payload = {
+            'product': self.product.id,
+            'customer': 'ACME',
+            'order_number': 1,
+            'items': [
+                {'subproduct': self.sub1.id, 'cutting_quantity': 10},
+                {'subproduct': self.sub2.id, 'cutting_quantity': 5}
+            ]
+        }
+        resp = self.client.post(url, payload, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(CuttingOrder.objects.count(), 1)
+        order = CuttingOrder.objects.first()
+        self.assertEqual(order.items.count(), 2)
+
+    def test_operator_edit_items_flag(self):
+        # Crear orden con flag False
+        order = CuttingOrder.objects.create(product=self.product, customer='A', order_number=2,
+                                            operator_can_edit_items=False, created_by=self.admin,
+                                            assigned_to=self.operator)
+        url = reverse('cutting_order_detail', args=[order.id])
+        self.client.force_authenticate(user=self.operator)
+        payload = {'items': [{'subproduct': self.sub1.id, 'cutting_quantity': 1}]}
+        resp = self.client.patch(url, payload, format='json')
+        self.assertEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+        # Ahora con flag True
+        order.operator_can_edit_items = True
+        order.save(user=self.admin)
+        resp = self.client.patch(url, payload, format='json')
+        self.assertNotEqual(resp.status_code, status.HTTP_403_FORBIDDEN)
+


### PR DESCRIPTION
## Summary
- extend CuttingOrder model with product relation and operator_can_edit_items flag
- update serializer to include product and subproduct checks
- adjust repository and services for new fields and multi-item logic
- allow operator item editing based on flag in views
- document new behaviour in docs
- add basic tests for CRUD updates

## Testing
- `python manage.py test apps.cuts.tests_new -v 2` *(fails: Connection to Redis)*

------
https://chatgpt.com/codex/tasks/task_e_6861e4d44c90832b974e8c25017f1097