### PR TITLE
Add signed image URL field

### DIFF
--- a/apps/storages_client/utils.py
+++ b/apps/storages_client/utils.py
@@ -1,0 +1,7 @@
+
+"""Utilidades públicas para operaciones comunes de almacenamiento."""
+
+from .services.s3_file_access import generate_presigned_url
+
+__all__ = ["generate_presigned_url"]
+

--- a/apps/users/api/serializers/user_detail_serializers.py
+++ b/apps/users/api/serializers/user_detail_serializers.py
@@ -1,18 +1,21 @@
 from rest_framework import serializers
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from apps.storages_client.services.profile_image import get_profile_image_url
+from apps.storages_client.utils import generate_presigned_url
 
 User = get_user_model()
 
 
 class UserDetailSerializer(serializers.ModelSerializer):
     image_url = serializers.SerializerMethodField(read_only=True)
+    image_signed_url = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = User
         fields = [
             'id', 'username', 'email', 'name', 'last_name',
-            'dni', 'image', 'image_url', 'is_staff', 'is_active'
+            'dni', 'image', 'image_url', 'image_signed_url', 'is_staff', 'is_active'
         ]
         read_only_fields = fields
 
@@ -28,3 +31,13 @@ class UserDetailSerializer(serializers.ModelSerializer):
             return get_profile_image_url(obj.image)
 
         return None
+
+    def get_image_signed_url(self, obj):
+        """Retorna una URL presignada para la imagen de perfil."""
+        if not obj.image:
+            return None
+        return generate_presigned_url(
+            bucket=settings.AWS_PROFILE_BUCKET_NAME,
+            object_name=obj.image
+        )
+


### PR DESCRIPTION
## Summary
- expose `generate_presigned_url` helper
- add `image_signed_url` field to user detail serializer

## Testing
- `python manage.py test` *(fails: NOT NULL constraint failed, missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_686312e77a8c832b82c5585c44834cfc