### PR TITLE
Add presigned URL field

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,3 +135,18 @@ La arquitectura de este proyecto sigue un patrón tradicional de MVC (Modelo-Vis
 - **Base de Datos**: PostgreSQL
 - **Autenticación**: JWT (JSON Web Tokens)
 - **Control de Versiones**: Git y GitHub
+
+## **Pruebas**
+
+Para ejecutar las pruebas de la aplicación utiliza la configuración de tests incluida. Esto evita dependencias externas como Redis.
+
+```bash
+DJANGO_SETTINGS_MODULE=inventory_management.settings.test python manage.py test
+```
+
+También puedes usar `pytest` de la siguiente forma:
+
+```bash
+DJANGO_SETTINGS_MODULE=inventory_management.settings.test python -m pytest -q
+```
+

--- a/apps/storages_client/__init__.py
+++ b/apps/storages_client/__init__.py
@@ -1,0 +1,4 @@
+from .utils import generate_presigned_url
+
+__all__ = ["generate_presigned_url"]
+

--- a/apps/storages_client/utils.py
+++ b/apps/storages_client/utils.py
@@ -1,0 +1,7 @@
+
+"""Utilidades públicas para operaciones comunes de almacenamiento."""
+
+from .services.s3_file_access import generate_presigned_url
+
+__all__ = ["generate_presigned_url"]
+

--- a/apps/users/api/serializers/user_detail_serializers.py
+++ b/apps/users/api/serializers/user_detail_serializers.py
@@ -1,18 +1,21 @@
 from rest_framework import serializers
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from apps.storages_client.services.profile_image import get_profile_image_url
+from apps.storages_client.utils import generate_presigned_url
 
 User = get_user_model()
 
 
 class UserDetailSerializer(serializers.ModelSerializer):
     image_url = serializers.SerializerMethodField(read_only=True)
+    image_signed_url = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = User
         fields = [
             'id', 'username', 'email', 'name', 'last_name',
-            'dni', 'image', 'image_url', 'is_staff', 'is_active'
+            'dni', 'image', 'image_url', 'image_signed_url', 'is_staff', 'is_active'
         ]
         read_only_fields = fields
 
@@ -28,3 +31,14 @@ class UserDetailSerializer(serializers.ModelSerializer):
             return get_profile_image_url(obj.image)
 
         return None
+
+    def get_image_signed_url(self, obj):
+        """Retorna una URL presignada para la imagen de perfil."""
+        if not obj.image or not isinstance(obj.image, str):
+            return None
+
+        return generate_presigned_url(
+            bucket=settings.AWS_PROFILE_BUCKET_NAME,
+            object_name=obj.image
+        )
+

--- a/inventory_management/settings/test.py
+++ b/inventory_management/settings/test.py
@@ -1,0 +1,25 @@
+from .local import *
+
+# Use in-memory database
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': ':memory:',
+    }
+}
+
+# Use in-memory channel layer to avoid Redis dependency
+CHANNEL_LAYERS = {
+    'default': {
+        'BACKEND': 'channels.layers.InMemoryChannelLayer',
+    }
+}
+
+# Execute Celery tasks locally
+CELERY_TASK_ALWAYS_EAGER = True
+CELERY_TASK_EAGER_PROPAGATES = True
+CELERY_BROKER_URL = 'memory://'
+CELERY_RESULT_BACKEND = 'cache+memory://'
+
+# Local email backend to capture emails in memory
+EMAIL_BACKEND = 'django.core.mail.backends.locmem.EmailBackend'


### PR DESCRIPTION
## Summary
- expose `generate_presigned_url` helper
- add `image_signed_url` field to user detail serializer
- add dedicated test settings and testing instructions
- refine signed image URL helper

## Testing
- `DJANGO_SETTINGS_MODULE=inventory_management.settings.test python manage.py test -v 1` *(fails: IntegrityError and missing modules)*
- `DJANGO_SETTINGS_MODULE=inventory_management.settings.test python -m pytest -q` *(fails: AppRegistryNotReady and missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686312e77a8c832b82c5585c44834cfc