### PR TITLE
Add basic repository unit tests

### DIFF
--- a/apps/products/tests.py
+++ b/apps/products/tests.py
@@ -1,2 +1,33 @@
-import unittest
-raise unittest.SkipTest("Legacy tests")
+from django.test import TestCase
+
+from apps.tests.factories import create_user, create_category, create_type, create_product
+from apps.products.api.repositories.product_repository import ProductRepository
+from apps.products.models import Product
+from django.core.cache import cache
+
+
+class ProductRepositoryTestCase(TestCase):
+    def setUp(self):
+        cache.delete_pattern = lambda *args, **kwargs: None
+        self.user = create_user(username='repo_user', email='repo@example.com')
+        self.category = create_category(name='Cat1', user=self.user)
+        self.type = create_type(self.category, name='Type1', user=self.user)
+
+    def test_create_and_get_product(self):
+        product = ProductRepository.create(
+            name='Prod1',
+            description='Desc',
+            category_id=self.category.id,
+            type_id=self.type.id,
+            user=self.user,
+        )
+        self.assertIsInstance(product, Product)
+        fetched = ProductRepository.get_by_id(product.id)
+        self.assertEqual(fetched.id, product.id)
+        self.assertEqual(fetched.name, 'Prod1')
+
+    def test_soft_delete_product(self):
+        product = create_product(self.category, self.type, user=self.user, name='Prod2')
+        ProductRepository.soft_delete(product, user=self.user)
+        self.assertFalse(product.status)
+        self.assertIsNone(ProductRepository.get_by_id(product.id))

--- a/apps/stocks/tests/test_model.py
+++ b/apps/stocks/tests/test_model.py
@@ -1,2 +1,38 @@
-import unittest
-raise unittest.SkipTest("Legacy tests")
+from django.test import TestCase
+
+from apps.tests.factories import (
+    create_user,
+    create_category,
+    create_type,
+    create_product,
+    create_product_stock,
+)
+from apps.stocks.api.repositories.stock_product_repository import StockProductRepository
+from apps.stocks.models import ProductStock
+from django.core.cache import cache
+
+
+class StockProductRepositoryTestCase(TestCase):
+    def setUp(self):
+        cache.delete_pattern = lambda *args, **kwargs: None
+        self.user = create_user(username='stock_user', email='stock@example.com')
+        self.category = create_category(name='CatStock', user=self.user)
+        self.type = create_type(self.category, name='TypeStock', user=self.user)
+        self.product = create_product(self.category, self.type, user=self.user, name='ProdStock')
+
+    def test_create_and_get_stock(self):
+        stock = StockProductRepository.create_stock(self.product, 5, self.user)
+        self.assertIsInstance(stock, ProductStock)
+        fetched = StockProductRepository.get_stock_for_product(self.product)
+        self.assertEqual(fetched.id, stock.id)
+        self.assertEqual(fetched.quantity, stock.quantity)
+
+    def test_soft_delete_stock(self):
+        stock = create_product_stock(self.product, 3, user=self.user)
+        StockProductRepository.soft_delete_stock(stock, user=self.user)
+        self.assertFalse(stock.status)
+        self.assertIsNone(StockProductRepository.get_by_stock_id(stock.id))
+
+    def test_create_stock_negative_quantity(self):
+        with self.assertRaises(ValueError):
+            StockProductRepository.create_stock(self.product, -1, self.user)

--- a/apps/tests/factories.py
+++ b/apps/tests/factories.py
@@ -1,0 +1,63 @@
+from apps.users.models import User
+from apps.products.api.repositories.product_repository import ProductRepository
+from apps.products.models import Category, Type
+from apps.stocks.api.repositories.stock_product_repository import StockProductRepository
+
+
+def create_user(**kwargs) -> User:
+    defaults = {
+        'username': 'testuser',
+        'email': 'user@example.com',
+        'password': 'pass',
+        'name': 'Test',
+        'last_name': 'User',
+        'dni': '1234567890',
+    }
+    defaults.update(kwargs)
+    return User.objects.create_user(
+        username=defaults['username'],
+        email=defaults['email'],
+        password=defaults['password'],
+        name=defaults['name'],
+        last_name=defaults['last_name'],
+        dni=defaults.get('dni'),
+    )
+
+
+def create_category(**kwargs) -> Category:
+    defaults = {'name': 'Category', 'description': 'desc'}
+    defaults.update(kwargs)
+    category = Category(
+        name=defaults['name'],
+        description=defaults.get('description'),
+    )
+    category.save(user=defaults.get('user'))
+    return category
+
+
+def create_type(category: Category, **kwargs) -> Type:
+    defaults = {'name': 'Type', 'description': 'desc'}
+    defaults.update(kwargs)
+    type_obj = Type(
+        category=category,
+        name=defaults['name'],
+        description=defaults.get('description'),
+    )
+    type_obj.save(user=defaults.get('user'))
+    return type_obj
+
+
+def create_product(category: Category, type_obj: Type | None = None, user=None, **kwargs):
+    defaults = {'name': 'Product', 'description': 'desc'}
+    defaults.update(kwargs)
+    return ProductRepository.create(
+        name=defaults['name'],
+        description=defaults['description'],
+        category_id=category.id,
+        type_id=type_obj.id if type_obj else None,
+        user=user,
+    )
+
+
+def create_product_stock(product, quantity: float = 0, user=None):
+    return StockProductRepository.create_stock(product=product, quantity=quantity, user=user)

--- a/inventory_management/settings/test.py
+++ b/inventory_management/settings/test.py
@@ -30,3 +30,11 @@ DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
 MEDIA_ROOT = BASE_DIR / 'test_media'
 
 MINIO_PUBLIC_URL = 'localhost:9000'
+
+# Use local memory cache to avoid Redis dependency in tests
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'test-cache',
+    }
+}


### PR DESCRIPTION
## Summary
- add factory helpers for tests
- implement ProductRepository tests
- implement StockProductRepository tests
- configure tests to use local memory cache

## Testing
- `DJANGO_SETTINGS_MODULE=inventory_management.settings.test python manage.py test apps.products.tests apps.stocks.tests.test_model -v 2`

------
https://chatgpt.com/codex/tasks/task_e_6865dc03548c832b80abf947eedcbd77