### PR TITLE
Fix Redis cache clearing after product file upload

### DIFF
--- a/apps/products/api/views/category_view.py
+++ b/apps/products/api/views/category_view.py
@@ -69,8 +69,8 @@ def create_category(request):
     if serializer.is_valid():
         category = serializer.save(user=request.user)
         # invalida todas las cachés de lista de categorías
-        redis = get_redis_connection()
-        redis.delete_pattern(f"{CACHE_KEY_CATEGORY_LIST}*")
+        redis_client = get_redis_connection("default")
+        redis_client.delete_pattern(f"{CACHE_KEY_CATEGORY_LIST}*")
         return Response(
             CategorySerializer(category, context={'request': request}).data,
             status=status.HTTP_201_CREATED
@@ -134,8 +134,8 @@ def category_detail(request, category_pk):
                 description=serializer.validated_data.get('description')
             )
             # invalida todas las cachés de lista de categorías
-            redis = get_redis_connection()
-            redis.delete_pattern(f"{CACHE_KEY_CATEGORY_LIST}*")
+            redis_client = get_redis_connection("default")
+            redis_client.delete_pattern(f"{CACHE_KEY_CATEGORY_LIST}*")
             return Response(CategorySerializer(updated_category, context={'request': request}).data)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -147,7 +147,7 @@ def category_detail(request, category_pk):
         if serializer.is_valid():
             serializer.save(user=request.user)
             # invalida todas las cachés de lista de categorías
-            redis = get_redis_connection()
-            redis.delete_pattern(f"{CACHE_KEY_CATEGORY_LIST}*")
+            redis_client = get_redis_connection("default")
+            redis_client.delete_pattern(f"{CACHE_KEY_CATEGORY_LIST}*")
             return Response(status=status.HTTP_204_NO_CONTENT)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/products/api/views/product_files_view.py
+++ b/apps/products/api/views/product_files_view.py
@@ -85,8 +85,8 @@ def product_file_upload_view(request, product_id: str):
 
     if results:
         # 1) Invalida todas las cachés de lista (páginas, filtros...)
-        redis = get_redis_connection()
-        redis.delete_pattern(f"{PRODUCT_LIST_CACHE_PREFIX}*")
+        redis_client = get_redis_connection("default")
+        redis_client.delete_pattern(f"{PRODUCT_LIST_CACHE_PREFIX}*")
         # 2) Invalida detalle concreto
         cache.delete(product_detail_cache_key(product_id))
 
@@ -144,8 +144,8 @@ def product_file_delete_view(request, product_id: str, file_id: str):
         delete_product_file(file_id)
         ProductFileRepository.delete(file_id)
         # 1) Invalida todas las cachés de lista (páginas, filtros...)
-        redis = get_redis_connection()
-        redis.delete_pattern(f"{PRODUCT_LIST_CACHE_PREFIX}*")
+        redis_client = get_redis_connection("default")
+        redis_client.delete_pattern(f"{PRODUCT_LIST_CACHE_PREFIX}*")
         # 2) Invalida detalle concreto
         cache.delete(product_detail_cache_key(product_id))
         return Response({"detail": "Archivo eliminado correctamente."}, status=status.HTTP_200_OK)

--- a/apps/products/api/views/subproduct_files_view.py
+++ b/apps/products/api/views/subproduct_files_view.py
@@ -81,8 +81,8 @@ def subproduct_file_upload_view(request, product_id: str, subproduct_id: str):
 
     if results:
         # invalida todas las cachés de lista de subproductos
-        redis = get_redis_connection()
-        redis.delete_pattern(f"{SUBPRODUCT_LIST_CACHE_PREFIX}*")
+        redis_client = get_redis_connection("default")
+        redis_client.delete_pattern(f"{SUBPRODUCT_LIST_CACHE_PREFIX}*")
         # invalida detalle concreto
         cache.delete(subproduct_detail_cache_key(product_id, subproduct_id))
 
@@ -175,8 +175,8 @@ def subproduct_file_delete_view(request, product_id: str, subproduct_id: str, fi
         delete_subproduct_file(file_id)
         SubproductFileRepository.delete(file_id)
         # invalida todas las cachés de lista de subproductos
-        redis = get_redis_connection()
-        redis.delete_pattern(f"{SUBPRODUCT_LIST_CACHE_PREFIX}*")
+        redis_client = get_redis_connection("default")
+        redis_client.delete_pattern(f"{SUBPRODUCT_LIST_CACHE_PREFIX}*")
         # invalida detalle concreto
         cache.delete(subproduct_detail_cache_key(product_id, subproduct_id))
         return Response({"detail": "Archivo eliminado correctamente."}, status=status.HTTP_200_OK)

--- a/apps/products/api/views/subproducts_view.py
+++ b/apps/products/api/views/subproducts_view.py
@@ -114,8 +114,8 @@ def create_subproduct(request, prod_pk):
         return Response({"detail": str(e)}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     # 1) Invalido todas las cachés de lista de subproductos
-    redis = get_redis_connection()
-    redis.delete_pattern(f"{SUBPRODUCT_LIST_CACHE_PREFIX}*")
+    redis_client = get_redis_connection("default")
+    redis_client.delete_pattern(f"{SUBPRODUCT_LIST_CACHE_PREFIX}*")
     # 2) (Opcional) Invalido la caché de detalle de este subproducto recién creado
     cache.delete(subproduct_detail_cache_key(prod_pk, subp.pk))
 
@@ -207,8 +207,8 @@ def subproduct_detail(request, prod_pk, subp_pk):
             return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         # Invalido todas las cachés de lista de subproductos
-        redis = get_redis_connection()
-        redis.delete_pattern(f"{SUBPRODUCT_LIST_CACHE_PREFIX}*")
+        redis_client = get_redis_connection("default")
+        redis_client.delete_pattern(f"{SUBPRODUCT_LIST_CACHE_PREFIX}*")
         # Invalido caché de detalle concreto
         cache.delete(cache_key_detail)
 
@@ -226,8 +226,8 @@ def subproduct_detail(request, prod_pk, subp_pk):
             return Response({"detail": "Error interno al eliminar el subproducto."}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         
        # Invalido todas las cachés de lista de subproductos
-        redis = get_redis_connection()
-        redis.delete_pattern(f"{SUBPRODUCT_LIST_CACHE_PREFIX}*")
+        redis_client = get_redis_connection("default")
+        redis_client.delete_pattern(f"{SUBPRODUCT_LIST_CACHE_PREFIX}*")
         # Invalido caché de detalle concreto
         cache.delete(cache_key_detail)
 

--- a/apps/products/api/views/types_view.py
+++ b/apps/products/api/views/types_view.py
@@ -67,8 +67,8 @@ def create_type(request):
     if serializer.is_valid():
         type_instance = serializer.save(user=request.user)
         # invalida todas las cachés de lista de tipos
-        redis = get_redis_connection()
-        redis.delete_pattern(f"{CACHE_KEY_TYPE_LIST}*")
+        redis_client = get_redis_connection("default")
+        redis_client.delete_pattern(f"{CACHE_KEY_TYPE_LIST}*")
         return Response(
             TypeSerializer(type_instance, context={'request': request}).data,
             status=status.HTTP_201_CREATED
@@ -127,8 +127,8 @@ def type_detail(request, type_pk):
         if serializer.is_valid():
             updated = serializer.save(user=request.user)
             # invalida todas las cachés de lista de tipos
-            redis = get_redis_connection()
-            redis.delete_pattern(f"{CACHE_KEY_TYPE_LIST}*")
+            redis_client = get_redis_connection("default")
+            redis_client.delete_pattern(f"{CACHE_KEY_TYPE_LIST}*")
             return Response(TypeSerializer(updated, context={'request': request}).data)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
@@ -140,7 +140,7 @@ def type_detail(request, type_pk):
         if serializer.is_valid():
             serializer.save(user=request.user)
             # invalida todas las cachés de lista de tipos
-            redis = get_redis_connection()
-            redis.delete_pattern(f"{CACHE_KEY_TYPE_LIST}*")
+            redis_client = get_redis_connection("default")
+            redis_client.delete_pattern(f"{CACHE_KEY_TYPE_LIST}*")
             return Response(status=status.HTTP_204_NO_CONTENT)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/products/tests.py
+++ b/apps/products/tests.py
@@ -31,3 +31,60 @@ class ProductRepositoryTestCase(TestCase):
         ProductRepository.soft_delete(product, user=self.user)
         self.assertFalse(product.status)
         self.assertIsNone(ProductRepository.get_by_id(product.id))
+
+from rest_framework.test import APIClient
+from django.core.files.uploadedfile import SimpleUploadedFile
+from unittest.mock import patch, MagicMock
+from rest_framework import status
+from apps.users.models import User
+from apps.products.utils.cache_helpers import PRODUCT_LIST_CACHE_PREFIX
+from apps.products.models.product_image_model import ProductImage
+
+
+class ProductFileViewsTestCase(TestCase):
+    def setUp(self):
+        cache.delete_pattern = lambda *args, **kwargs: None
+        self.admin = User.objects.create_superuser(
+            username="admin",
+            email="admin@example.com",
+            password="pass",
+            name="Admin",
+            last_name="User",
+        )
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.admin)
+        self.category = create_category(name="Cat", user=self.admin)
+        self.type = create_type(self.category, name="Type", user=self.admin)
+        self.product = create_product(self.category, self.type, user=self.admin)
+
+    @patch("apps.products.api.views.product_files_view.get_redis_connection")
+    @patch("apps.products.api.views.product_files_view.upload_product_file")
+    def test_upload_file_clears_cache(self, mock_upload, mock_get_redis):
+        mock_upload.return_value = {
+            "key": "k",
+            "url": "http://example.com",
+            "name": "f.pdf",
+            "mimeType": "application/pdf",
+        }
+        redis_mock = MagicMock()
+        mock_get_redis.return_value = redis_mock
+
+        file = SimpleUploadedFile("f.pdf", b"data", content_type="application/pdf")
+        url = f"/api/v1/inventory/products/{self.product.id}/files/upload/"
+        response = self.client.post(url, {"file": file}, format="multipart")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        redis_mock.delete_pattern.assert_called_with(f"{PRODUCT_LIST_CACHE_PREFIX}*")
+
+    @patch("apps.products.api.views.product_files_view.get_redis_connection")
+    @patch("apps.products.api.views.product_files_view.delete_product_file")
+    def test_delete_file_clears_cache(self, mock_delete_file, mock_get_redis):
+        redis_mock = MagicMock()
+        mock_get_redis.return_value = redis_mock
+
+        image = ProductImage.objects.create(product=self.product, key="k2")
+        url = f"/api/v1/inventory/products/{self.product.id}/files/{image.key}/delete/"
+        response = self.client.delete(url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        redis_mock.delete_pattern.assert_called_with(f"{PRODUCT_LIST_CACHE_PREFIX}*")
+
+


### PR DESCRIPTION
## Summary
- ensure django-redis connection uses the default alias
- add regression tests for cache invalidation on product files

## Testing
- `DJANGO_SETTINGS_MODULE=inventory_management.settings.test python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_687669614820832baa3c727816a625cb